### PR TITLE
Patch for bug 116323

### DIFF
--- a/src/blowfish/blf.h
+++ b/src/blowfish/blf.h
@@ -44,8 +44,8 @@
 
 /* Blowfish context */
 typedef struct BlowfishContext {
-	u_int32_t S[4][256];	/* S-Boxes */
-	u_int32_t P[BLF_N + 2];	/* Subkeys */
+	uint32_t S[4][256];	/* S-Boxes */
+	uint32_t P[BLF_N + 2];	/* Subkeys */
 } blf_ctx;
 
 /* Raw access to customized Blowfish
@@ -54,24 +54,24 @@ typedef struct BlowfishContext {
  *	Blowfish_expand0state( state, key, keylen )
  */
 
-void Blowfish_encipher(blf_ctx *, u_int32_t *, u_int32_t *);
-void Blowfish_decipher(blf_ctx *, u_int32_t *, u_int32_t *);
+void Blowfish_encipher(blf_ctx *, uint32_t *, uint32_t *);
+void Blowfish_decipher(blf_ctx *, uint32_t *, uint32_t *);
 void Blowfish_initstate(blf_ctx *);
-void Blowfish_expand0state(blf_ctx *, const u_int8_t *, u_int16_t);
+void Blowfish_expand0state(blf_ctx *, const uint8_t *, uint16_t);
 void Blowfish_expandstate
-(blf_ctx *, const u_int8_t *, u_int16_t, const u_int8_t *, u_int16_t);
+(blf_ctx *, const uint8_t *, uint16_t, const uint8_t *, uint16_t);
 
 /* Standard Blowfish */
 
-void blf_key(blf_ctx *, const u_int8_t *, u_int16_t);
-void blf_enc(blf_ctx *, u_int32_t *, u_int16_t);
-void blf_dec(blf_ctx *, u_int32_t *, u_int16_t);
+void blf_key(blf_ctx *, const uint8_t *, uint16_t);
+void blf_enc(blf_ctx *, uint32_t *, uint16_t);
+void blf_dec(blf_ctx *, uint32_t *, uint16_t);
 
-void blf_ecb_encrypt(blf_ctx *, u_int8_t *, u_int32_t);
-void blf_ecb_decrypt(blf_ctx *, u_int8_t *, u_int32_t);
+void blf_ecb_encrypt(blf_ctx *, uint8_t *, uint32_t);
+void blf_ecb_decrypt(blf_ctx *, uint8_t *, uint32_t);
 
-void blf_cbc_encrypt(blf_ctx *, u_int8_t *, u_int8_t *, u_int32_t);
-void blf_cbc_decrypt(blf_ctx *, u_int8_t *, u_int8_t *, u_int32_t);
+void blf_cbc_encrypt(blf_ctx *, uint8_t *, uint8_t *, uint32_t);
+void blf_cbc_decrypt(blf_ctx *, uint8_t *, uint8_t *, uint32_t);
 
-/* Converts u_int8_t to u_int32_t */
-u_int32_t Blowfish_stream2word(const u_int8_t *, u_int16_t , u_int16_t *);
+/* Converts uint8_t to uint32_t */
+uint32_t Blowfish_stream2word(const uint8_t *, uint16_t , uint16_t *);

--- a/src/blowfish/blowfish.c
+++ b/src/blowfish/blowfish.c
@@ -64,12 +64,12 @@
 #define BLFRND(s,p,i,j,n) (i ^= FN(s,j) ^ (p)[n])
 
 void
-Blowfish_encipher(blf_ctx *c, u_int32_t *xl, u_int32_t *xr)
+Blowfish_encipher(blf_ctx *c, uint32_t *xl, uint32_t *xr)
 {
-	u_int32_t Xl;
-	u_int32_t Xr;
-	u_int32_t *s = c->S[0];
-	u_int32_t *p = c->P;
+	uint32_t Xl;
+	uint32_t Xr;
+	uint32_t *s = c->S[0];
+	uint32_t *p = c->P;
 
 	Xl = *xl;
 	Xr = *xr;
@@ -89,12 +89,12 @@ Blowfish_encipher(blf_ctx *c, u_int32_t *xl, u_int32_t *xr)
 }
 
 void
-Blowfish_decipher(blf_ctx *c, u_int32_t *xl, u_int32_t *xr)
+Blowfish_decipher(blf_ctx *c, uint32_t *xl, uint32_t *xr)
 {
-	u_int32_t Xl;
-	u_int32_t Xr;
-	u_int32_t *s = c->S[0];
-	u_int32_t *p = c->P;
+	uint32_t Xl;
+	uint32_t Xr;
+	uint32_t *s = c->S[0];
+	uint32_t *p = c->P;
 
 	Xl = *xl;
 	Xr = *xr;
@@ -392,13 +392,13 @@ Blowfish_initstate(blf_ctx *c)
 	*c = initstate;
 }
 
-u_int32_t
-Blowfish_stream2word(const u_int8_t *data, u_int16_t databytes,
-    u_int16_t *current)
+uint32_t
+Blowfish_stream2word(const uint8_t *data, uint16_t databytes,
+    uint16_t *current)
 {
-	u_int8_t i;
-	u_int16_t j;
-	u_int32_t temp;
+	uint8_t i;
+	uint16_t j;
+	uint32_t temp;
 
 	temp = 0x00000000;
 	j = *current;
@@ -414,14 +414,14 @@ Blowfish_stream2word(const u_int8_t *data, u_int16_t databytes,
 }
 
 void
-Blowfish_expand0state(blf_ctx *c, const u_int8_t *key, u_int16_t keybytes)
+Blowfish_expand0state(blf_ctx *c, const uint8_t *key, uint16_t keybytes)
 {
-	u_int16_t i;
-	u_int16_t j;
-	u_int16_t k;
-	u_int32_t temp;
-	u_int32_t datal;
-	u_int32_t datar;
+	uint16_t i;
+	uint16_t j;
+	uint16_t k;
+	uint32_t temp;
+	uint32_t datal;
+	uint32_t datar;
 
 	j = 0;
 	for (i = 0; i < BLF_N + 2; i++) {
@@ -452,15 +452,15 @@ Blowfish_expand0state(blf_ctx *c, const u_int8_t *key, u_int16_t keybytes)
 
 
 void
-Blowfish_expandstate(blf_ctx *c, const u_int8_t *data, u_int16_t databytes,
-    const u_int8_t *key, u_int16_t keybytes)
+Blowfish_expandstate(blf_ctx *c, const uint8_t *data, uint16_t databytes,
+    const uint8_t *key, uint16_t keybytes)
 {
-	u_int16_t i;
-	u_int16_t j;
-	u_int16_t k;
-	u_int32_t temp;
-	u_int32_t datal;
-	u_int32_t datar;
+	uint16_t i;
+	uint16_t j;
+	uint16_t k;
+	uint32_t temp;
+	uint32_t datal;
+	uint32_t datar;
 
 	j = 0;
 	for (i = 0; i < BLF_N + 2; i++) {
@@ -495,7 +495,7 @@ Blowfish_expandstate(blf_ctx *c, const u_int8_t *data, u_int16_t databytes,
 }
 
 void
-blf_key(blf_ctx *c, const u_int8_t *k, u_int16_t len)
+blf_key(blf_ctx *c, const uint8_t *k, uint16_t len)
 {
 	/* Initialize S-boxes and subkeys with Pi */
 	Blowfish_initstate(c);
@@ -505,10 +505,10 @@ blf_key(blf_ctx *c, const u_int8_t *k, u_int16_t len)
 }
 
 void
-blf_enc(blf_ctx *c, u_int32_t *data, u_int16_t blocks)
+blf_enc(blf_ctx *c, uint32_t *data, uint16_t blocks)
 {
-	u_int32_t *d;
-	u_int16_t i;
+	uint32_t *d;
+	uint16_t i;
 
 	d = data;
 	for (i = 0; i < blocks; i++) {
@@ -518,10 +518,10 @@ blf_enc(blf_ctx *c, u_int32_t *data, u_int16_t blocks)
 }
 
 void
-blf_dec(blf_ctx *c, u_int32_t *data, u_int16_t blocks)
+blf_dec(blf_ctx *c, uint32_t *data, uint16_t blocks)
 {
-	u_int32_t *d;
-	u_int16_t i;
+	uint32_t *d;
+	uint16_t i;
 
 	d = data;
 	for (i = 0; i < blocks; i++) {
@@ -531,10 +531,10 @@ blf_dec(blf_ctx *c, u_int32_t *data, u_int16_t blocks)
 }
 
 void
-blf_ecb_encrypt(blf_ctx *c, u_int8_t *data, u_int32_t len)
+blf_ecb_encrypt(blf_ctx *c, uint8_t *data, uint32_t len)
 {
-	u_int32_t l, r;
-	u_int32_t i;
+	uint32_t l, r;
+	uint32_t i;
 
 	for (i = 0; i < len; i += 8) {
 		l = data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
@@ -553,10 +553,10 @@ blf_ecb_encrypt(blf_ctx *c, u_int8_t *data, u_int32_t len)
 }
 
 void
-blf_ecb_decrypt(blf_ctx *c, u_int8_t *data, u_int32_t len)
+blf_ecb_decrypt(blf_ctx *c, uint8_t *data, uint32_t len)
 {
-	u_int32_t l, r;
-	u_int32_t i;
+	uint32_t l, r;
+	uint32_t i;
 
 	for (i = 0; i < len; i += 8) {
 		l = data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
@@ -575,10 +575,10 @@ blf_ecb_decrypt(blf_ctx *c, u_int8_t *data, u_int32_t len)
 }
 
 void
-blf_cbc_encrypt(blf_ctx *c, u_int8_t *iv, u_int8_t *data, u_int32_t len)
+blf_cbc_encrypt(blf_ctx *c, uint8_t *iv, uint8_t *data, uint32_t len)
 {
-	u_int32_t l, r;
-	u_int32_t i, j;
+	uint32_t l, r;
+	uint32_t i, j;
 
 	for (i = 0; i < len; i += 8) {
 		for (j = 0; j < 8; j++)
@@ -600,11 +600,11 @@ blf_cbc_encrypt(blf_ctx *c, u_int8_t *iv, u_int8_t *data, u_int32_t len)
 }
 
 void
-blf_cbc_decrypt(blf_ctx *c, u_int8_t *iva, u_int8_t *data, u_int32_t len)
+blf_cbc_decrypt(blf_ctx *c, uint8_t *iva, uint8_t *data, uint32_t len)
 {
-	u_int32_t l, r;
-	u_int8_t *iv;
-	u_int32_t i, j;
+	uint32_t l, r;
+	uint8_t *iv;
+	uint32_t i, j;
 
 	iv = data + len - 16;
 	data = data + len - 8;


### PR DESCRIPTION
https://rt.cpan.org/Ticket/Display.html?id=116323

On Solaris blowfish will not compile without the C99 type standard
ex. uint32_t

Fix is to substitute u_intXX_t with uintXX_t for blf.h and blowfish.c
