### PR TITLE
Fix attempt to load Net/SSH/Perl/Key/.pm module

### DIFF
--- a/lib/Net/SSH/Perl/Key.pm
+++ b/lib/Net/SSH/Perl/Key.pm
@@ -37,6 +37,7 @@ sub new_from_blob {
     my $b = Net::SSH::Perl::Buffer->new( MP => 'SSH1' );
     $b->append($blob);
     my $ssh_name = $b->get_str;
+    if (!exists($KEY_TYPES{$ssh_name})) { die("Unexpected key type provided"); }
     my $type = $KEY_TYPES{$ssh_name};
     __PACKAGE__->new($type, @_);
 }

--- a/t/20-bug-invalid-key-type-in-key-blob.t
+++ b/t/20-bug-invalid-key-type-in-key-blob.t
@@ -1,0 +1,42 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2017 Joel C. Maslak
+# All Rights Reserved - See License
+#
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Net::SSH::Perl::Buffer;
+use Net::SSH::Perl::Key;
+
+my $b = Net::SSH::Perl::Buffer->new( MP => 'SSH2' );
+$b->put_str('ssh-rsa'),
+$b->put_str("x" x 8);   # Fake key part
+$b->put_str("x" x 64);  # Fake key part
+my $blob = $b->bytes;
+
+my $res = eval { Net::SSH::Perl::Key->new_from_blob($blob); };
+ok(defined($res), 'ssh-rsa key blob works');
+
+$b = Net::SSH::Perl::Buffer->new( MP => 'SSH2' );
+$b->put_str('foo-bar-invalid-name'),
+$b->put_str("x" x 8);   # Fake key part
+$b->put_str("x" x 64);  # Fake key part
+$blob = $b->bytes;
+
+$res = eval { Net::SSH::Perl::Key->new_from_blob($blob); };
+my $error = $@;
+ok(!defined($res), 'did not create invalid key object');
+unlike($error, qr/Can't locate/s, 'did not attempt to load invalid class');
+like($error, qr/Unexpected key type provided/s, 'did die with a nicer error');
+print $error, "\n";
+
+done_testing;
+
+1;
+
+


### PR DESCRIPTION
If a server sends a key blob (for instance in a SSH2_MSG_KEX_DH_GEX_REPLY)
where the key blob has a key that belongs to a type not known to
Net::SSH::Perl, Net::SSH::Perl will attempt to load a module named
Net::SSH::Perl::Key::.pm.  This replaces that behavior with a more
user-friendly message and removes the attempt to load the invalid module.
It also ensures that even if the user is catching some exceptions, that
%NET::SSH::Perl::Key::KEY_TYPES doesn't get the invalid key type added to itself.

I also added a simple test for this bug.