### PR TITLE
import: handle/ignore unknown export tags

### DIFF
--- a/lib/Net/SSH/Perl/Util.pm
+++ b/lib/Net/SSH/Perl/Util.pm
@@ -46,7 +46,7 @@ sub import {
     my @args = @_;
     for my $item (@args) {
         push @to_export,
-            $item =~ s/^:// ? @{ $EXPORT_TAGS{$item} } : $item;
+            $item =~ s/^:// ? @{ $EXPORT_TAGS{$item} || [] } : $item;
     }
 
     my %loaded;


### PR DESCRIPTION
This is a hotfix I had to pick up for the v2.12 cpan release. Unfortunately I don't find a corresponding RT or github ticket anymore to remember who reported it. It was some legacy code (on CPAN?) that specified a non-existent import tag.