### PR TITLE
Allow fallback to no compression if compression is enabled.

### DIFF
--- a/lib/Net/SSH/Perl/Kex.pm
+++ b/lib/Net/SSH/Perl/Kex.pm
@@ -75,7 +75,7 @@ sub exchange {
     }
     if ($ssh->config->get('compression')) {
         $proposal[ PROPOSAL_COMP_ALGS_CTOS ] =
-        $proposal[ PROPOSAL_COMP_ALGS_STOC ] = "zlib";
+        $proposal[ PROPOSAL_COMP_ALGS_STOC ] = "zlib,none";
     }
     else {
         $proposal[ PROPOSAL_COMP_ALGS_CTOS ] =


### PR DESCRIPTION
This will make Net::SSH::Perl match openssl’s behavior. (At least, I assume that fallback is preferred to failing the connection?)

Thank you!